### PR TITLE
PLAT-8636-use-internal-docker-mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim
+FROM docker.twtools.io/docker_io/library/ruby:2.7-slim
 
 ARG CH_version=19.3.4
 


### PR DESCRIPTION
Closes PLAT-8636.